### PR TITLE
refactor - update destroy_minishell function to remove parameter 

### DIFF
--- a/inc/minishell.h
+++ b/inc/minishell.h
@@ -6,7 +6,7 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/21 15:36:34 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 03:08:51 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:31:16 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,7 +60,7 @@ void		init_minishell(t_msh *msh, char **envp);
 
 void		free_minishell_loop(t_msh *msh);
 
-void		destroy_minishell(t_msh *msh);
+void		destroy_minishell(void);
 
 void		sigint_action(int sig);
 

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -6,7 +6,7 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/25 02:39:32 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 00:52:54 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:31:35 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,6 +47,6 @@ int	msh_exit(t_msh *msh, t_command *cmd)
 	}
 	else
 		status_num = msh->last_status;
-	destroy_minishell(msh);
+	destroy_minishell();
 	exit(status_num);
 }

--- a/src/core.c
+++ b/src/core.c
@@ -6,7 +6,7 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/05 00:46:52 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 01:00:38 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:31:07 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,8 +42,11 @@ void	free_minishell_loop(t_msh *msh)
 		ft_delpointer((void **) &msh->input);
 }
 
-void	destroy_minishell(t_msh *msh)
+void	destroy_minishell(void)
 {
+	t_msh	*msh;
+
+	msh = get_minishell();
 	rl_clear_history();
 	free_minishell_loop(msh);
 	if (msh->env_vars)

--- a/src/execute/launch_process.c
+++ b/src/execute/launch_process.c
@@ -6,24 +6,23 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/28 18:17:49 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 02:55:56 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:33:26 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	exit_child_process(t_msh *msh, t_list *cmd_node,
-			int input_fd, int exit_code)
+static void	exit_child_process(t_list *cmd_node, int input_fd, int exit_code)
 {
 	if (input_fd == STDIN_FILENO || !cmd_node->next)
 		close(STDIN_FILENO);
 	if (!cmd_node->next)
 		close(STDOUT_FILENO);
-	destroy_minishell(msh);
+	destroy_minishell();
 	exit(exit_code);
 }
 
-static void	setup_child_pipes(t_msh *msh, t_list *cmd_node, int input_fd)
+static void	setup_child_pipes(t_list *cmd_node, int input_fd)
 {
 	t_command	*cmd;
 
@@ -33,7 +32,7 @@ static void	setup_child_pipes(t_msh *msh, t_list *cmd_node, int input_fd)
 		if (dup2(input_fd, STDIN_FILENO) == -1)
 		{
 			perror("minishell: dup2");
-			exit_child_process(msh, cmd_node, input_fd, 1);
+			exit_child_process(cmd_node, input_fd, 1);
 		}
 		close(input_fd);
 	}
@@ -43,7 +42,7 @@ static void	setup_child_pipes(t_msh *msh, t_list *cmd_node, int input_fd)
 		if (dup2(cmd->pipe_fd[1], STDOUT_FILENO) == -1)
 		{
 			perror("minishell: dup2");
-			exit_child_process(msh, cmd_node, input_fd, 1);
+			exit_child_process(cmd_node, input_fd, 1);
 		}
 		close(cmd->pipe_fd[1]);
 	}
@@ -56,11 +55,11 @@ static void	child_process(t_msh *msh, t_list *cmd_node, int input_fd,
 	int			exit_code;
 
 	cmd = (t_command *)cmd_node->content;
-	setup_child_pipes(msh, cmd_node, input_fd);
+	setup_child_pipes(cmd_node, input_fd);
 	if (!apply_redirections(cmd))
-		exit_child_process(msh, cmd_node, input_fd, 1);
+		exit_child_process(cmd_node, input_fd, 1);
 	exit_code = launcher(msh, cmd);
-	exit_child_process(msh, cmd_node, input_fd, exit_code);
+	exit_child_process(cmd_node, input_fd, exit_code);
 }
 
 static int	parent_process(t_list *cmd_node, pid_t pid, int input_fd)

--- a/src/execute/setup_heredocs.c
+++ b/src/execute/setup_heredocs.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   open_heredoc.c                                     :+:      :+:    :+:   */
+/*   setup_heredocs.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 03:52:03 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 03:06:37 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:31:35 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ static void	process_heredoc_child(t_msh *msh, t_command *cmd, char *delim,
 		exit(EXIT_FAILURE);
 	}
 	close(heredoc_fd[1]);
-	destroy_minishell(msh);
+	destroy_minishell();
 	exit(EXIT_SUCCESS);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/22 14:03:30 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 02:46:19 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:31:35 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,6 @@ int	main(int argc, char **argv, char **envp)
 		free_minishell_loop(msh);
 	}
 	ft_putstr_fd("exit\n", 1);
-	destroy_minishell(msh);
+	destroy_minishell();
 	return (0);
 }

--- a/src/signal/signal_handlers.c
+++ b/src/signal/signal_handlers.c
@@ -6,7 +6,7 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 03:19:15 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 02:09:25 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:33:44 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,13 +31,10 @@ void	sigint_process_action(int sig)
 
 void	sigint_heredoc_action(int sig)
 {
-	t_msh	*msh;
-
-	msh = get_minishell();
 	if (sig == SIGINT)
 	{
 		ft_putchar_fd('\n', 1);
-		destroy_minishell(msh);
+		destroy_minishell();
 		exit(EXIT_FAILURE);
 	}
 }


### PR DESCRIPTION
This pull request focuses on refactoring the `destroy_minishell` function to remove the `t_msh` parameter, making it a parameterless function that retrieves the `t_msh` instance internally. The changes span multiple files to ensure consistency across the codebase.

Refactoring `destroy_minishell` function:

* [`inc/minishell.h`](diffhunk://#diff-71ac2db5fec65368c16ab9fc572b50749d817e528958ff7471446e3ece847671L63-R63): Updated the `destroy_minishell` function declaration to remove the `t_msh` parameter.
* [`src/core.c`](diffhunk://#diff-fb5d19f8f1d70c287f3d5682180afe1805a186fb126fec004524f3c530ca6059L45-R49): Modified the `destroy_minishell` function to retrieve the `t_msh` instance internally using the `get_minishell` function.
* [`src/builtin/exit.c`](diffhunk://#diff-1c5ccecc962e119523b1a77d15402223113bc40aac431ab4ed8c48d3079b31baL50-R50): Updated calls to `destroy_minishell` to match the new parameterless function signature.
* [`src/execute/launch_process.c`](diffhunk://#diff-6c5d4a519d0e74b3f6d5a7120990c73fab06e926d18adbc65fae1bc43f1569e7L9-R25): Updated calls to `destroy_minishell` and related functions to match the new parameterless function signature. [[1]](diffhunk://#diff-6c5d4a519d0e74b3f6d5a7120990c73fab06e926d18adbc65fae1bc43f1569e7L9-R25) [[2]](diffhunk://#diff-6c5d4a519d0e74b3f6d5a7120990c73fab06e926d18adbc65fae1bc43f1569e7L36-R35) [[3]](diffhunk://#diff-6c5d4a519d0e74b3f6d5a7120990c73fab06e926d18adbc65fae1bc43f1569e7L46-R45) [[4]](diffhunk://#diff-6c5d4a519d0e74b3f6d5a7120990c73fab06e926d18adbc65fae1bc43f1569e7L59-R62)
* [`src/execute/setup_heredocs.c`](diffhunk://#diff-7df5ea245a1e2012a9f53e5e728620241ed7b58c12dbf05275bc3f9cbb311011L27-R27): Updated calls to `destroy_minishell` to match the new parameterless function signature.
* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176L64-R64): Updated calls to `destroy_minishell` to match the new parameterless function signature.
* [`src/signal/signal_handlers.c`](diffhunk://#diff-2555b90127dfddd0a34ed872e6aac493c6d5361747097e3ad4d04ce0a37a79eaL34-R37): Updated calls to `destroy_minishell` to match the new parameterless function signature.…adjust calls