### PR TITLE
execute - add destroy_minishell call on heredoc capture failure

### DIFF
--- a/src/execute/setup_heredocs.c
+++ b/src/execute/setup_heredocs.c
@@ -6,7 +6,7 @@
 /*   By: jarao-de <jarao-de@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/01 03:52:03 by jarao-de          #+#    #+#             */
-/*   Updated: 2025/03/05 04:31:35 by jarao-de         ###   ########.fr       */
+/*   Updated: 2025/03/05 04:47:05 by jarao-de         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@ static void	process_heredoc_child(t_msh *msh, t_command *cmd, char *delim,
 	if (!capture_heredoc(msh, delim, heredoc_fd[1]))
 	{
 		close(heredoc_fd[1]);
+		destroy_minishell();
 		exit(EXIT_FAILURE);
 	}
 	close(heredoc_fd[1]);


### PR DESCRIPTION
This pull request includes a small but important change to the `src/execute/setup_heredocs.c` file. The change ensures proper cleanup by calling `destroy_minishell()` before exiting on failure in the `process_heredoc_child` function.

* [`src/execute/setup_heredocs.c`](diffhunk://#diff-7df5ea245a1e2012a9f53e5e728620241ed7b58c12dbf05275bc3f9cbb311011R24): Added a call to `destroy_minishell()` before exiting on failure in the `process_heredoc_child` function to ensure proper cleanup.